### PR TITLE
FIX webpack cli not working due to missing package

### DIFF
--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Updated webpack to v4.30 and webpack-dev-server to v3.3.
+
 # 1.1.0
 
 - Added webpack-cli dependency.

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-tools-webpack",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Configurations to use webpack",
   "main": "./index.js",
   "license": "MIT",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "glob": "~7.1.2",
-    "webpack": "~4.29.6",
+    "webpack": "~4.30.0",
     "webpack-cli": "~3.3.0",
-    "webpack-dev-server": "~3.2.1"
+    "webpack-dev-server": "~3.3.1"
   }
 }


### PR DESCRIPTION
We recently noticed that webpack builds failed with the error:

```
Error: Cannot find module 'webpack-cli/bin/config-yargs'
```

This seems to be a known issue on webpack side of a non backwards compatible change. Upgrading fixes it.